### PR TITLE
Fix auth bouncer response handling

### DIFF
--- a/go_api/cyclone/handlers.py
+++ b/go_api/cyclone/handlers.py
@@ -319,10 +319,10 @@ def owner_from_oauth2_bouncer(url_base):
         uri = "".join([url_base.rstrip('/'), request.uri])
         resp = yield treq.request(
             request.method, uri, headers=request.headers, persistent=False)
-        [owner] = resp.headers.getRawHeaders('X-Owner-Id')
         yield resp.content()
         if resp.code >= 400:
             raise HTTPError(resp.code)
+        [owner] = resp.headers.getRawHeaders('X-Owner-Id')
         returnValue(owner)
     return owner_factory
 

--- a/go_api/cyclone/tests/test_handlers.py
+++ b/go_api/cyclone/tests/test_handlers.py
@@ -684,10 +684,11 @@ class TestAuthHandlers(TestCase):
         self._cleanup_funcs.append(func)
 
     @inlineCallbacks
-    def start_fake_auth_server(self, owner_id, code=200):
+    def start_fake_auth_server(self, owner_id=None, code=200):
         def auth_request(request):
             request.setResponseCode(code)
-            request.setHeader("X-Owner-Id", owner_id)
+            if owner_id is not None:
+                request.setHeader("X-Owner-Id", owner_id)
             return ""
         fake_server = MockHttpServer(auth_request)
         yield fake_server.start()
@@ -738,7 +739,7 @@ class TestAuthHandlers(TestCase):
 
     @inlineCallbacks
     def test_owner_from_bouncer_without_value(self):
-        auth_server = yield self.start_fake_auth_server("owner-1", 401)
+        auth_server = yield self.start_fake_auth_server(code=401)
         preprocessor = owner_from_oauth2_bouncer(auth_server.url)
         handler = self.dummy_helper.mk_handler()
         err = yield self.assertFailure(preprocessor(handler), HTTPError)
@@ -746,7 +747,7 @@ class TestAuthHandlers(TestCase):
 
     @inlineCallbacks
     def test_owner_from_bouncer_with_invalid_value(self):
-        auth_server = yield self.start_fake_auth_server("owner-1", 403)
+        auth_server = yield self.start_fake_auth_server(code=403)
         preprocessor = owner_from_oauth2_bouncer(auth_server.url)
         handler = self.dummy_helper.mk_handler(
             headers={"Authorization": "Bearer foo"})


### PR DESCRIPTION
We incorrectly assume the bouncer response will contain the `X-Owner-Id` header in all cases.
